### PR TITLE
Change Field handling to uint32_t

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ build_flags =
 
 extra_scripts = favicon_script.py
 
-build_version = v0.15.01-beta
+build_version = v0.15.03-beta
 
 [env:wemos_dev]
 led_name = LED Dev

--- a/src/LED_strip/led_strip.cpp
+++ b/src/LED_strip/led_strip.cpp
@@ -49,209 +49,140 @@
 
 WS2812FX *strip;
 
-bool isField(const char * name, FieldList fields, uint8_t count)
-{
-  for (uint8_t i = 0; i < count; i++)
-  {
-    if (strcmp(fields[i].name, name) == 0)
-    {
-      return true;
-    }
-  }
-  return false;
-}
-
-Field getField(const char * name, FieldList fields, uint8_t count)
-{
-  for (uint8_t i = 0; i < count; i++)
-  {
-    Field field = fields[i];
-    if (strcmp(field.name, name) == 0)
-    {
-      return field;
-    }
-  }
-  return Field();
-}
-
-String getFieldValue(const char * name, FieldList fields, uint8_t count)
-{
-  Field field = getField(name, fields, count);
-  if (field.getValue)
-  {
-    DynamicJsonBuffer buffer;
-    JsonArray& a = buffer.createArray();
-    switch (field.type)
-    {
-    case NumberFieldType:
-      return String(field.getValue());
-      break;
-    case BooleanFieldType:
-      if(field.getValue())
-      {
-        return "on";
-      }
-      return "off";
-      break;
-    case SelectFieldType:
-      field.getOptions(a);
-      return a[field.getValue()].as<const char*>(); //.asString();
-      break;
-    case ColorFieldType:
-      return String((*strip->getSegment()).solidColor);
-    break;
-    default:
-      break;
-    }
-    return String(field.getValue());
-  }
-  return String();
-}
-
-void setFieldValue(const char * name, uint16_t value, FieldList fields, uint8_t count)
-{
-  Field field = getField(name, fields, count);
-  if (field.setValue)
-  {
-    field.setValue(value);
-  }
-}
-
 
 /*
- *
- * get Values
- * 
- */
-inline uint16_t getPower() {
-  return (uint16_t)(strip->getPower());
+*
+* get Values
+* 
+*/
+inline uint32_t getPower() {
+  return (uint32_t)(strip->getPower());
 }
-inline uint16_t getIsRunning(void) {
-  return (uint16_t)(strip->isRunning());
+inline uint32_t getIsRunning(void) {
+  return (uint32_t)(strip->isRunning());
 }
-inline uint16_t getBrightness() {
-  return (uint16_t)(strip->getBrightness());
+inline uint32_t getBrightness() {
+  return (uint32_t)(strip->getBrightness());
 }
-inline uint16_t getPattern() {
-  return (uint16_t)(strip->getMode());
+inline uint32_t getPattern() {
+  return (uint32_t)(strip->getMode());
 }
-inline uint16_t getPalette() {
-  return (uint16_t)(strip->getTargetPaletteNumber());
+inline uint32_t getPalette() {
+  return (uint32_t)(strip->getTargetPaletteNumber());
 }
-inline uint16_t getSpeed() {
-  return (uint16_t)(strip->getBeat88());
+inline uint32_t getSpeed() {
+  return (uint32_t)(strip->getBeat88());
 }
-inline uint16_t getBlendType() {
-  return (uint16_t)(strip->getBlendType());
+inline uint32_t getBlendType() {
+  return (uint32_t)(strip->getBlendType());
 }
-inline uint16_t getColorTemp() {
-  return (uint16_t)(strip->getColorTemp());
+inline uint32_t getColorTemp() {
+  return (uint32_t)(strip->getColorTemp());
 }
-inline uint16_t getBlurValue(void) {
-  return (uint16_t)(strip->getBlurValue());
+inline uint32_t getBlurValue(void) {
+  return (uint32_t)(strip->getBlurValue());
 }
-inline uint16_t getReverse() {
-  return (uint16_t)(strip->getReverse());
+inline uint32_t getReverse() {
+  return (uint32_t)(strip->getReverse());
 }
-inline uint16_t getSegments(void) {
-  return (uint16_t)(strip->getSegments());
+inline uint32_t getSegments(void) {
+  return (uint32_t)(strip->getSegments());
 }
-inline uint16_t getMirror() {
-  return (uint16_t)(strip->getMirror());
+inline uint32_t getMirror() {
+  return (uint32_t)(strip->getMirror());
 }
-inline uint16_t getAddGlitter(void) {
-  return (uint16_t)(strip->getAddGlitter());
+inline uint32_t getAddGlitter(void) {
+  return (uint32_t)(strip->getAddGlitter());
 }
-inline uint16_t getWhiteOnly(void) {
-  return (uint16_t)(strip->getWhiteGlitter());
+inline uint32_t getWhiteOnly(void) {
+  return (uint32_t)(strip->getWhiteGlitter());
 }
-inline uint16_t getOnBlackOnly(void) {
-  return (uint16_t)(strip->getOnBlackOnly());
+inline uint32_t getOnBlackOnly(void) {
+  return (uint32_t)(strip->getOnBlackOnly());
 }
-inline uint16_t getSynched(void) {
-  return (uint16_t)(strip->getSynchronous());
+inline uint32_t getSynched(void) {
+  return (uint32_t)(strip->getSynchronous());
 }
-inline uint16_t getHueTime() {
-  return (uint16_t)(strip->getHueTime());
+inline uint32_t getHueTime() {
+  return (uint32_t)(strip->getHueTime());
 }
-inline uint16_t getDeltaHue()
+inline uint32_t getDeltaHue()
 {
-  return (uint16_t)(strip->getDeltaHue());
+  return (uint32_t)(strip->getDeltaHue());
 }
-inline uint16_t getAutoplay() {
-  return (uint16_t)(strip->getAutoplay());
+inline uint32_t getAutoplay() {
+  return (uint32_t)(strip->getAutoplay());
 }
-inline uint16_t getAutoplayDuration() {
-  return (uint16_t)(strip->getAutoplayDuration());
+inline uint32_t getAutoplayDuration() {
+  return (uint32_t)(strip->getAutoplayDuration());
 }
-inline uint16_t getAutopal() {
-  return (uint16_t)(strip->getAutopal());
+inline uint32_t getAutopal() {
+  return (uint32_t)(strip->getAutopal());
 }
-inline uint16_t getAutopalDuration(){
-  return (uint16_t)(strip->getAutopalDuration());
+inline uint32_t getAutopalDuration(){
+  return (uint32_t)(strip->getAutopalDuration());
 }
-inline uint16_t getSolidColor() {
-  //CRGB solidColor = (*strip->getTargetPalette()).entries[0];
-  //return (uint16_t)(solidColor.r) + "," + String(solidColor.g) + "," + String(solidColor.b);
-  return 250; // hmmm what to do with this solid color field? limit t one byte? Change all to uint32 to enable color?
+inline uint32_t getSolidColor() {
+  CRGB solidColor = strip->getSolidColor();
+  return ((solidColor.r << 16 | solidColor.g << 8 | solidColor.b << 0) & 0x00ffffff);
 }
-inline uint16_t getCooling() {
-  return (uint16_t)(strip->getCooling());
+inline uint32_t getCooling() {
+  return (uint32_t)(strip->getCooling());
 }
-inline uint16_t getSparking() {
-  return (uint16_t)(strip->getSparking());
+inline uint32_t getSparking() {
+  return (uint32_t)(strip->getSparking());
 }
-inline uint16_t getTwinkleSpeed() {
-  return (uint16_t)(strip->getTwinkleSpeed());
+inline uint32_t getTwinkleSpeed() {
+  return (uint32_t)(strip->getTwinkleSpeed());
 }
-inline uint16_t getTwinkleDensity() {
-  return (uint16_t)(strip->getTwinkleDensity());
+inline uint32_t getTwinkleDensity() {
+  return (uint32_t)(strip->getTwinkleDensity());
 }
-inline uint16_t getNumBars() {
-  return (uint16_t)(strip->getNumBars());
+inline uint32_t getNumBars() {
+  return (uint32_t)(strip->getNumBars());
 }
-inline uint16_t getDamping() {
-  return (uint16_t)(strip->getDamping());
+inline uint32_t getDamping() {
+  return (uint32_t)(strip->getDamping());
 }
-inline uint16_t getSunRiseTime(void) {
-  return (uint16_t)(strip->getSunriseTime());
+inline uint32_t getSunRiseTime(void) {
+  return (uint32_t)(strip->getSunriseTime());
 }
-inline uint16_t getMilliamps(void) {
-  return (uint16_t)(strip->getMilliamps());
+inline uint32_t getMilliamps(void) {
+  return (uint32_t)(strip->getMilliamps());
 }
-inline uint16_t getFPSValue(void) {
-  return (uint16_t)(strip->getMaxFPS());
+inline uint32_t getFPSValue(void) {
+  return (uint32_t)(strip->getMaxFPS());
 }
-inline uint16_t getDithering(void) {
-  return (uint16_t)(strip->getDithering());
+inline uint32_t getDithering(void) {
+  return (uint32_t)(strip->getDithering());
 }
-inline uint16_t getResetDefaults(void) {
-  return (uint16_t)(0);
+inline uint32_t getResetDefaults(void) {
+  return (uint32_t)(0);
 }
-inline uint16_t getBckndHue() {
-  return (uint16_t)(strip->getBckndHue());
+inline uint32_t getBckndHue() {
+  return (uint32_t)(strip->getBckndHue());
 }
-inline uint16_t getBckndSat() {
-  return (uint16_t)(strip->getBckndSat());
+inline uint32_t getBckndSat() {
+  return (uint32_t)(strip->getBckndSat());
 }
-inline uint16_t getBckndBri() {
-  return (uint16_t)(strip->getBckndBri());
+inline uint32_t getBckndBri() {
+  return (uint32_t)(strip->getBckndBri());
 }
-inline uint16_t getColCor() {
-  return (uint16_t)(strip->getColorCorrectionEnum());
+inline uint32_t getColCor() {
+  return (uint32_t)(strip->getColorCorrectionEnum());
 }
 
 
 #ifdef HAS_KNOB_CONTROL
-inline uint16_t getWiFiDisabled(void) {
-  return (uint16_t)(strip->getWiFiDisabled());
+inline uint32_t getWiFiDisabled(void) {
+  return (uint32_t)(strip->getWiFiDisabled());
 }
 #endif
 
 /*
- * Options
- * 
- */
+* Options
+* 
+*/
 void getPatterns(JsonArray &jArr) {
   const uint8_t count = strip->getModeCount();
   for (uint8_t i = 0; i < count; i++)
@@ -295,135 +226,132 @@ void getColCorValues(JsonArray &jArr) {
 }
 
 /*
- * Setters
- * 
- */
+* Setters
+* 
+*/
 
-void setPower(uint16_t val) {
+void setPower(uint32_t val) {
   strip->setPower(val);
   if(val)
     strip->setIsRunning(val);
 }
-void setIsRunning(uint16_t val) {
+void setIsRunning(uint32_t val) {
   strip->setIsRunning(val); 
 }
-void setBrightness(uint16_t val) {
+void setBrightness(uint32_t val) {
   strip->setBrightness(val);
 }
-void setPattern(uint16_t val) {
+void setPattern(uint32_t val) {
   strip->setMode(val);
 }
-void setPalette(uint16_t val) {
+void setPalette(uint32_t val) {
   strip->setTargetPalette(val);
 }
-void setSpeed(uint16_t val) {
+void setSpeed(uint32_t val) {
   strip->setBeat88(val);
 }
-void setBlendType(uint16_t val) {
+void setBlendType(uint32_t val) {
   strip->setBlendType((TBlendType)val);
 }
-void setColorTemp(uint16_t val) {
+void setColorTemp(uint32_t val) {
   strip->setColorTemp(val);
 }
-void setBlurValue(uint16_t val) {
+void setBlurValue(uint32_t val) {
   strip->setBlur(val);
 }
-void setReverse(uint16_t val) {
+void setReverse(uint32_t val) {
   strip->setReverse(val);
 }
-void setSegments(uint16_t val) {
+void setSegments(uint32_t val) {
   strip->setSegments(val);
 }
-void setMirror(uint16_t val) {
+void setMirror(uint32_t val) {
   strip->setMirror(val);
 }
-void setAddGlitter(uint16_t val) {
+void setAddGlitter(uint32_t val) {
   strip->setAddGlitter(val);
 }
-void setWhiteOnly(uint16_t val) {
+void setWhiteOnly(uint32_t val) {
   strip->setWhiteGlitter(val);
 }
-void setOnBlackOnly(uint16_t val) {
+void setOnBlackOnly(uint32_t val) {
   strip->setOnBlackOnly(val);
 }
-void setSynched(uint16_t val) {
+void setSynched(uint32_t val) {
   strip->setSynchronous(val);
 }
-void setHueTime(uint16_t val) {
+void setHueTime(uint32_t val) {
   strip->setHuetime(val);
 }
-void setDeltaHue(uint16_t val) {
+void setDeltaHue(uint32_t val) {
   strip->setDeltaHue(val);
 }
-void setAutoplayMode(uint16_t val) {
+void setAutoplayMode(uint32_t val) {
   strip->setAutoplay((AUTOPLAYMODES)val);
 }
-void setAutoplayDuration(uint16_t val) {
+void setAutoplayDuration(uint32_t val) {
   strip->setAutoplayDuration(val);
 }
-void setAutopal(uint16_t val) {
+void setAutopal(uint32_t val) {
   strip->setAutopal((AUTOPLAYMODES)val);
 }
-void setAutopalDuration(uint16_t val) {
-strip->setAutopalDuration(val);
+void setAutopalDuration(uint32_t val) {
+  strip->setAutopalDuration(val);
 }
-/*
-// Currently no valuable solution for this
-void setSolidColor(uint16_t val) {
-strip->set... 
+void setSolidColor(uint32_t val) {
+  strip->setSolidColor(val);
 }
-*/
-void setCooling(uint16_t val) {
+void setCooling(uint32_t val) {
   strip->setCooling(val);
 }
-void setSparking(uint16_t val) {
+void setSparking(uint32_t val) {
   strip->setSparking(val);
 }
-void setTwinkleSpeed(uint16_t val) {
+void setTwinkleSpeed(uint32_t val) {
   strip->setTwinkleSpeed(val);
 }
-void setTwinkleDensity(uint16_t val) {
+void setTwinkleDensity(uint32_t val) {
   strip->setTwinkleDensity(val);
 }
-void setNumBars(uint16_t val) {
+void setNumBars(uint32_t val) {
   strip->setNumBars(val);
 }
-void setDamping(uint16_t val) {
+void setDamping(uint32_t val) {
   strip->setDamping(val);
 }
-void setSunRiseTime(uint16_t val) {
+void setSunRiseTime(uint32_t val) {
   strip->setSunriseTime(val);
 }
-void setMilliamps(uint16_t val) {
+void setMilliamps(uint32_t val) {
   strip->setMilliamps(val);
 }
-void setFPSValue(uint16_t val) {
+void setFPSValue(uint32_t val) {
   strip->setMaxFPS(val);
 }
-void setDithering(uint16_t val) {
+void setDithering(uint32_t val) {
   strip->setDithering(val);
 }
-void setResetDefaults(uint16_t val) {
+void setResetDefaults(uint32_t val) {
   if(val)
   {
     strip->resetDefaults();
   }
 }
-void setBckndHue(uint16_t val) {
+void setBckndHue(uint32_t val) {
   strip->setBckndHue(val);
 }
-void setBckndSat(uint16_t val) {
+void setBckndSat(uint32_t val) {
   strip->setBckndSat(val);
 }
-void setBckndBri(uint16_t val) {
+void setBckndBri(uint32_t val) {
   strip->setBckndBri(val);
 }
-void setColCor(uint16_t val) {
+void setColCor(uint32_t val) {
   strip->setColCor((COLORCORRECTIONS)val);
 }
 
 #ifdef HAS_KNOB_CONTROL
-void setWiFiDisabled(uint16_t val) {
+void setWiFiDisabled(uint32_t val) {
   if(val)
     strip->setWiFiDisabled(true);
   else
@@ -447,63 +375,62 @@ String getResets() {
 }
 #endif
 
-FieldList fields = {
-  {"title",             LED_NAME,                       TitleFieldType,     0,                                   0,                                             NULL,               NULL,           NULL          },
-  {"s_powerSection",    "Power / Effects",              SectionFieldType,   0,                                   0,                                             NULL,               NULL,           NULL          },
-  {"power",             "On/Off",                       BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getPower,           NULL,           setPower      },
+const Field fields [] = {
+  {"title",             LED_NAME,                       TitleFieldType,     0,                                   0,                                             nullptr,               nullptr,           nullptr          },
+  {"s_powerSection",    "Power / Effects",              SectionFieldType,   0,                                   0,                                             nullptr,               nullptr,           nullptr          },
+  {"power",             "On/Off",                       BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getPower,           nullptr,           setPower      },
   {"effect",            "Effect",                       SelectFieldType,    (uint16_t)0,                            (uint16_t)strip->getModeCount(),                  getPattern,         getPatterns,    setPattern    },
-  {"brightness",        "Brightness",                   NumberFieldType,    (uint16_t)BRIGHTNESS_MIN,               (uint16_t)BRIGHTNESS_MAX,                         getBrightness,      NULL,           setBrightness },
-  {"speed",             "Speed",                        NumberFieldType,    (uint16_t)BEAT88_MIN,                   (uint16_t)BEAT88_MAX,                             getSpeed,           NULL,           setSpeed      },
+  {"brightness",        "Brightness",                   NumberFieldType,    (uint16_t)BRIGHTNESS_MIN,               (uint16_t)BRIGHTNESS_MAX,                         getBrightness,      nullptr,           setBrightness },
+  {"speed",             "Speed",                        NumberFieldType,    (uint16_t)BEAT88_MIN,                   (uint16_t)BEAT88_MAX,                             getSpeed,           nullptr,           setSpeed      },
   {"colorPalette",      "Color palette",                SelectFieldType,    (uint16_t)0,                            (uint16_t)(strip->getPalCount() + 1),             getPalette,         getPalettes,    setPalette    },
-  {"running",           "Pause",                        BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getIsRunning,       NULL,           setIsRunning  },
-  {"s_stripeStruture",  "Structure",                    SectionFieldType,   0,                                   0,                                             NULL,               NULL,           NULL          },
-  {"segments",          "Segments",                     NumberFieldType,    (uint16_t)1,                            (uint16_t)max(MAX_NUM_SEGMENTS, 1),               getSegments,        NULL,           setSegments   },
-  {"numEffectBars",     "# LED bars",                   NumberFieldType,    (uint16_t)1,                            (uint16_t)max(MAX_NUM_BARS, 1),                   getNumBars,         NULL,           setNumBars                    },
-  {"reversed",          "Reverse",                      BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getReverse,         NULL,           setReverse    },
-  {"mirrored",          "Mirror",                       BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getMirror,          NULL,           setMirror     },
-  {"s_Autoplay",        "Autoplay",                     SectionFieldType,   0,                                   0,                                             NULL,               NULL,           NULL          },
+  {"running",           "Pause",                        BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getIsRunning,       nullptr,           setIsRunning  },
+  {"s_stripeStruture",  "Structure",                    SectionFieldType,   0,                                   0,                                             nullptr,               nullptr,           nullptr          },
+  {"segments",          "Segments",                     NumberFieldType,    (uint16_t)1,                            (uint16_t)max(MAX_NUM_SEGMENTS, 1),               getSegments,        nullptr,           setSegments   },
+  {"numEffectBars",     "# LED bars",                   NumberFieldType,    (uint16_t)1,                            (uint16_t)max(MAX_NUM_BARS, 1),                   getNumBars,         nullptr,           setNumBars                    },
+  {"reversed",          "Reverse",                      BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getReverse,         nullptr,           setReverse    },
+  {"mirrored",          "Mirror",                       BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getMirror,          nullptr,           setMirror     },
+  {"s_Autoplay",        "Autoplay",                     SectionFieldType,   0,                                   0,                                             nullptr,               nullptr,           nullptr          },
   {"autoPlay",          "Auto mode change",             SelectFieldType,    (uint16_t)AUTO_MODE_OFF,                (uint16_t)AUTO_MODE_RANDOM,                       getAutoplay,        getAutoplayModes, setAutoplayMode             },
-  {"autoPlayInterval",  "Auto mode interval (s)",       NumberFieldType,    (uint16_t)DEFAULT_T_AUTOMODE_MIN,       (uint16_t)DEFAULT_T_AUTOMODE_MAX,                 getAutoplayDuration, NULL,          setAutoplayDuration           },
+  {"autoPlayInterval",  "Auto mode interval (s)",       NumberFieldType,    (uint16_t)DEFAULT_T_AUTOMODE_MIN,       (uint16_t)DEFAULT_T_AUTOMODE_MAX,                 getAutoplayDuration, nullptr,          setAutoplayDuration           },
   {"autoPalette",       "Auto palette change",          SelectFieldType,    (uint16_t)AUTO_MODE_OFF,                (uint16_t)AUTO_MODE_RANDOM,                       getAutopal,         getAutoplayModes, setAutopal                  },
-  {"autoPalInterval",   "Auto palette interval (s)",    NumberFieldType,    (uint16_t)DEFAULT_T_AUTOCOLOR_MIN,      (uint16_t)DEFAULT_T_AUTOCOLOR_MAX,                                   getAutopalDuration, NULL,           setAutopalDuration            },
-  {"s_BackGroundColor", "Bcknd Color",                  SectionFieldType,   0,                                   0,                                             NULL,               NULL,           NULL                          },
-  {"backgroundHue",     "Bcknd Hue",                    NumberFieldType,    (uint16_t)0,                            (uint16_t)255,                                    getBckndHue,        NULL,           setBckndHue                   },
-  {"backgroundSat",     "Bcknd Sat",                    NumberFieldType,    (uint16_t)0,                            (uint16_t)255,                                    getBckndSat,        NULL,           setBckndSat                   },
-  {"backgroundBri",     "Bcknd Bri",                    NumberFieldType,    (uint16_t)BCKND_MIN_BRI,                (uint16_t)BCKND_MAX_BRI,                          getBckndBri,        NULL,           setBckndBri                   },
-  {"s_advancedControl", "Advanced",                     SectionFieldType,   0,                                   0,                                             NULL,               NULL,           NULL                          },
+  {"autoPalInterval",   "Auto palette interval (s)",    NumberFieldType,    (uint16_t)DEFAULT_T_AUTOCOLOR_MIN,      (uint16_t)DEFAULT_T_AUTOCOLOR_MAX,                                   getAutopalDuration, nullptr,           setAutopalDuration            },
+  {"s_BackGroundColor", "Bcknd Color",                  SectionFieldType,   0,                                   0,                                             nullptr,               nullptr,           nullptr                          },
+  {"backgroundHue",     "Bcknd Hue",                    NumberFieldType,    (uint16_t)0,                            (uint16_t)255,                                    getBckndHue,        nullptr,           setBckndHue                   },
+  {"backgroundSat",     "Bcknd Sat",                    NumberFieldType,    (uint16_t)0,                            (uint16_t)255,                                    getBckndSat,        nullptr,           setBckndSat                   },
+  {"backgroundBri",     "Bcknd Bri",                    NumberFieldType,    (uint16_t)BCKND_MIN_BRI,                (uint16_t)BCKND_MAX_BRI,                          getBckndBri,        nullptr,           setBckndBri                   },
+  {"s_advancedControl", "Advanced",                     SectionFieldType,   0,                                   0,                                             nullptr,               nullptr,           nullptr                          },
   {"blendType",         "Color blend",                  SelectFieldType,    (uint16_t)NOBLEND,                      (uint16_t)LINEARBLEND,                            getBlendType,       getBlendTypes,  setBlendType                  },
   {"colorTemperature",  "Color temperature",            SelectFieldType,    (uint16_t)0,                            (uint16_t)20,                                     getColorTemp,       getColorTemps,  setColorTemp                  },
-  {"ledBlur",           "Effect blur / blending",       NumberFieldType,    (uint16_t)0,                            (uint16_t)255,                                    getBlurValue,       NULL,           setBlurValue                  },
-  {"s_solidColor",      "Solid color",                  SectionFieldType,   0,                                   0,                                             NULL,               NULL,           NULL                          },
-  {"solidColor",        "Color",                        ColorFieldType,     (uint16_t)0,                            (uint16_t)55,                                     getSolidColor,      NULL,           NULL                          },
-  {"s_glitter",         "Glitter",                      SectionFieldType,   0,                                   0,                                             NULL,               NULL,           NULL                          },
-  {"addGlitter",        "Add Glitter",                  BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getAddGlitter,      NULL,           setAddGlitter                 },
-  {"whiteGlitter",      "White Glitter",                BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getWhiteOnly,       NULL,           setWhiteOnly                  },
-  {"onBlackOnly",       "On Black",                     BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getOnBlackOnly,     NULL,           setOnBlackOnly                },
-  {"syncGlitter",       "Sync Segments",                BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getSynched,         NULL,           setSynched,             },
-  {"s_basicHue",        "Hue Change",                   SectionFieldType,   0,                                   0,                                             NULL,               NULL,           NULL                          },
-  {"hueTime",           "Hue interval (ms)",            NumberFieldType,    (uint16_t)0,                            (uint16_t)5000,                                   getHueTime,         NULL,           setHueTime                    },
-  {"deltaHue",          "Hue Offset",                   NumberFieldType,    (uint16_t)0,                            (uint16_t)255,                                    getDeltaHue,        NULL,           setDeltaHue                   },    
-  {"s_effectSettings",  "Effect Settings",              SectionFieldType,   0,                                   0,                                             NULL,               NULL,           NULL                          },
-  {"cooling",           "Cooling",                      NumberFieldType,    (uint16_t)DEFAULT_COOLING_MIN,          (uint16_t)DEFAULT_COOLING_MAX,                    getCooling,         NULL,           setCooling},
-  {"sparking",          "Sparking",                     NumberFieldType,    (uint16_t)DEFAULT_SPARKING_MIN,         (uint16_t)DEFAULT_SPARKING_MAX,                   getSparking,        NULL,           setSparking                   },
-  {"twinkleSpeed",      "Twinkle speed",                NumberFieldType,    (uint16_t)DEFAULT_TWINKLE_S_MIN,        (uint16_t)DEFAULT_TWINKLE_S_MAX,                  getTwinkleSpeed,    NULL,           setTwinkleSpeed               },
-  {"twinkleDensity",    "Twinkle density",              NumberFieldType,    (uint16_t)DEFAULT_TWINKLE_NUM_MIN,      (uint16_t)DEFAULT_TWINKLE_NUM_MAX,                getTwinkleDensity,  NULL,           setTwinkleDensity             },
-  {"damping",           "damping for bounce",           NumberFieldType,    (uint16_t)DEFAULT_DAMPING_MIN,          (uint16_t)DEFAULT_DAMPING_MAX,                    getDamping,         NULL,           setDamping                    },
+  {"ledBlur",           "Effect blur / blending",       NumberFieldType,    (uint16_t)0,                            (uint16_t)255,                                    getBlurValue,       nullptr,           setBlurValue                  },
+  {"s_solidColor",      "Solid color",                  SectionFieldType,   0,                                   0,                                             nullptr,               nullptr,           nullptr                          },
+  {"solidColor",        "Color",                        ColorFieldType,     (uint16_t)0,                            (uint16_t)55,                                     getSolidColor,      nullptr,           setSolidColor                 },
+  {"s_glitter",         "Glitter",                      SectionFieldType,   0,                                   0,                                             nullptr,               nullptr,           nullptr                          },
+  {"addGlitter",        "Add Glitter",                  BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getAddGlitter,      nullptr,           setAddGlitter                 },
+  {"whiteGlitter",      "White Glitter",                BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getWhiteOnly,       nullptr,           setWhiteOnly                  },
+  {"onBlackOnly",       "On Black",                     BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getOnBlackOnly,     nullptr,           setOnBlackOnly                },
+  {"syncGlitter",       "Sync Segments",                BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getSynched,         nullptr,           setSynched,             },
+  {"s_basicHue",        "Hue Change",                   SectionFieldType,   0,                                   0,                                             nullptr,               nullptr,           nullptr                          },
+  {"hueTime",           "Hue interval (ms)",            NumberFieldType,    (uint16_t)0,                            (uint16_t)5000,                                   getHueTime,         nullptr,           setHueTime                    },
+  {"deltaHue",          "Hue Offset",                   NumberFieldType,    (uint16_t)0,                            (uint16_t)255,                                    getDeltaHue,        nullptr,           setDeltaHue                   },    
+  {"s_effectSettings",  "Effect Settings",              SectionFieldType,   0,                                   0,                                             nullptr,               nullptr,           nullptr                          },
+  {"cooling",           "Cooling",                      NumberFieldType,    (uint16_t)DEFAULT_COOLING_MIN,          (uint16_t)DEFAULT_COOLING_MAX,                    getCooling,         nullptr,           setCooling},
+  {"sparking",          "Sparking",                     NumberFieldType,    (uint16_t)DEFAULT_SPARKING_MIN,         (uint16_t)DEFAULT_SPARKING_MAX,                   getSparking,        nullptr,           setSparking                   },
+  {"twinkleSpeed",      "Twinkle speed",                NumberFieldType,    (uint16_t)DEFAULT_TWINKLE_S_MIN,        (uint16_t)DEFAULT_TWINKLE_S_MAX,                  getTwinkleSpeed,    nullptr,           setTwinkleSpeed               },
+  {"twinkleDensity",    "Twinkle density",              NumberFieldType,    (uint16_t)DEFAULT_TWINKLE_NUM_MIN,      (uint16_t)DEFAULT_TWINKLE_NUM_MAX,                getTwinkleDensity,  nullptr,           setTwinkleDensity             },
+  {"damping",           "damping for bounce",           NumberFieldType,    (uint16_t)DEFAULT_DAMPING_MIN,          (uint16_t)DEFAULT_DAMPING_MAX,                    getDamping,         nullptr,           setDamping                    },
   // time provided in Minutes and capped at 60 minutes actually.
-  {"sunriseset",        "sunrise, sunset time in min",  NumberFieldType,    (uint16_t)DEFAULT_SUNRISETIME_MIN,      (uint16_t)DEFAULT_SUNRISETIME_MAX,                getSunRiseTime,     NULL,           setSunRiseTime                }, 
-  {"s_otherSettings",   "Other settings",               SectionFieldType,   0,                                   0,                                             NULL,               NULL,           NULL                          },
+  {"sunriseset",        "sunrise, sunset time in min",  NumberFieldType,    (uint16_t)DEFAULT_SUNRISETIME_MIN,      (uint16_t)DEFAULT_SUNRISETIME_MAX,                getSunRiseTime,     nullptr,           setSunRiseTime                }, 
+  {"s_otherSettings",   "Other settings",               SectionFieldType,   0,                                   0,                                             nullptr,               nullptr,           nullptr                          },
   #ifdef HAS_KNOB_CONTROL
-  {"wifiDisabled",      "WiFi Disabled",                BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getWiFiDisabled,    NULL,           setWiFiDisabled               },  
+  {"wifiDisabled",      "WiFi Disabled",                BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getWiFiDisabled,    nullptr,           setWiFiDisabled               },  
   #endif
-  {"currentLimit",      "Current limit",                NumberFieldType,    (uint16_t)100,                          (uint16_t)DEFAULT_CURRENT_MAX,                    getMilliamps,       NULL,           setMilliamps                  },
+  {"currentLimit",      "Current limit",                NumberFieldType,    (uint16_t)100,                          (uint16_t)DEFAULT_CURRENT_MAX,                    getMilliamps,       nullptr,           setMilliamps                  },
   {"colorCorrection",   "ColorCorrection",              SelectFieldType,    (uint16_t)0,                            (uint16_t)(COR_NUMCORRECTIONS-1),                 getColCor,          getColCorValues, setColCor                    },
   // 111 max equals the minimum update time required for 300 pixels
   // this is the minimal delay being used anyway, so no use in being faster
-  {"fps",               "max FPS",                      NumberFieldType,    (uint16_t)STRIP_MIN_FPS,                (uint16_t)(STRIP_MAX_FPS),                        getFPSValue,        NULL,           setFPSValue                   },                                                                           
-  {"dithering",         "Dithering",                    BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getDithering,       NULL,           setDithering                  },
-  {"resetdefaults",     "Reset default",                BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getResetDefaults,   NULL,           setResetDefaults              },
-
+  {"fps",               "max FPS",                      NumberFieldType,    (uint16_t)STRIP_MIN_FPS,                (uint16_t)(STRIP_MAX_FPS),                        getFPSValue,        nullptr,           setFPSValue                   },                                                                           
+  {"dithering",         "Dithering",                    BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getDithering,       nullptr,           setDithering                  },
+  {"resetdefaults",     "Reset default",                BooleanFieldType,   (uint16_t)0,                            (uint16_t)1,                                      getResetDefaults,   nullptr,           setResetDefaults              },
 #ifdef DEBUG
   // With the DEBUG flag enabled we can provoke some resets (SOFT WDT, HW WDT, Exception...)
   {"S_Debug",           "DEBUG only - not for production",        SectionFieldType                                                                                                        },
@@ -511,17 +438,157 @@ FieldList fields = {
 #endif
 };
 
-
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(A) (sizeof(A) / sizeof((A)[0]))
 #endif
 
 uint8_t fieldCount = ARRAY_SIZE(fields);
 
-void stripe_setup(const uint8_t volt = (uint8_t)5,
+bool getAllValuesJSONArray(JsonArray &arr)
+{
+  bool ret = false;
+  for(uint8_t i=0; i<getFieldCount(); i++)
+  {
+    if(fields[i].type < TitleFieldType)
+    {
+      JsonObject &obj = arr.createNestedObject();
+      obj[F("name")] =  fields[i].name;
+      obj[F("value")] = fields[i].getValue();          
+      ret = true;
+    }
+  }
+  return ret;
+}
+
+
+void getAllJSON(JsonArray &arr)
+{
+  for (uint8_t i = 0; i < getFieldCount(); i++)
+  {
+    Field field = fields[i];
+    JsonObject& obj = arr.createNestedObject();
+    obj[F("name")]  = field.name;
+    obj[F("label")] = field.label;
+    obj[F("type")]  = (int)field.type;
+    if (field.getValue)
+    {
+      obj[F("value")] = field.getValue();
+    }
+
+    if (field.type == NumberFieldType) //(const char *)"Number")
+    {
+      obj[F("min")] = field.min;
+      obj[F("max")] = field.max;
+    }
+
+    if (field.getOptions)
+    {
+      JsonArray &ar = obj.createNestedArray(F("options"));
+      field.getOptions(ar);
+    }
+  }
+}
+
+
+bool getAllValuesJSON(JsonObject & obj)
+{
+  bool ret = false;
+  for(uint8_t i=0; i<getFieldCount(); i++)
+  {
+    if(fields[i].getValue)
+    {
+      ret = true;
+      obj[fields[i].name] = getFieldValue(fields[i].name);
+    }
+  }
+  return ret;
+}
+
+bool isField(const char * name)
+{
+  for (uint8_t i = 0; i < fieldCount; i++)
+  {
+    if (strcmp(fields[i].name, name) == 0)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+Field getField(const char * name)
+{
+  for (uint8_t i = 0; i < fieldCount; i++)
+  {
+    Field field = fields[i];
+    if (strcmp(field.name, name) == 0)
+    {
+      return field;
+    }
+  }
+  return Field();
+}
+
+String getFieldValue(const char * name)
+{
+  Field field = getField(name);
+  if (field.getValue)
+  {
+    DynamicJsonBuffer buffer;
+    JsonArray& a = buffer.createArray();
+    switch (field.type)
+    {
+    case NumberFieldType:
+      return String(field.getValue());
+      break;
+    case BooleanFieldType:
+      if(field.getValue())
+      {
+        return "on";
+      }
+      return "off";
+      break;
+    case SelectFieldType:
+      field.getOptions(a);
+      return a[field.getValue()].as<const char*>(); //.asString();
+      break;
+    case ColorFieldType:
+      return String(strip->getSolidColor());
+    break;
+    default:
+      break;
+    }
+    return String(field.getValue());
+  }
+  return String();
+}
+
+void setFieldValue(const char * name, uint32_t value)
+{
+  Field field = getField(name);
+  if (field.setValue)
+  {
+    field.setValue(value);
+  }
+}
+
+const Field * getFields(void)
+{
+  return (const Field*)fields;
+}
+
+
+uint8_t getFieldCount(void)
+{
+  return fieldCount;
+}
+
+  
+
+void stripe_setup(CRGB * pleds, CRGB* eleds, const uint8_t volt = (uint8_t)5,
                   const LEDColorCorrection colc = UncorrectedColor /*TypicalLEDStrip*/)
 {
-  strip = new WS2812FX(volt, colc);
+  strip = new WS2812FX(pleds, eleds, volt, colc);
   strip->init();
   strip->start();
   strip->show();

--- a/src/LED_strip/led_strip.h
+++ b/src/LED_strip/led_strip.h
@@ -61,7 +61,7 @@ extern WS2812FX *strip;
 // initialize the strip during boot (or at changes)
 // strip can be any neopixel arrangement
 // but is currently limited to NEO_GRB
-void stripe_setup(  const uint8_t volt ,
+void stripe_setup(  CRGB * pleds, CRGB* eleds, const uint8_t volt ,
                     const LEDColorCorrection colc);
 
 // Field.h
@@ -84,8 +84,8 @@ void stripe_setup(  const uint8_t volt ,
 */
 
 
-typedef void (*FieldSetter)(uint16_t);
-typedef uint16_t (*FieldGetter)();
+typedef void (*FieldSetter)(uint32_t);
+typedef uint32_t (*FieldGetter)();
 typedef void (*FieldGetterOpts)(JsonArray & arr);
 
 enum fieldtypes {
@@ -111,7 +111,6 @@ struct Field {
   FieldSetter setValue;
 };
 
-typedef Field FieldList[];
 
 // /End Field.h
 
@@ -134,35 +133,51 @@ typedef Field FieldList[];
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-Field getField(const char * name, FieldList fields, uint8_t count);
-String getFieldValue(const char * name, FieldList fields, uint8_t count);
-void setFieldValue(const char * name, uint16_t value, FieldList fields, uint8_t count);
-bool isField(const char * name, FieldList fields, uint8_t count);
-uint16_t getPower(void);
-uint16_t getMilliamps(void);
-uint16_t getBrightness(void);
-uint16_t getPattern(void);
-JsonArray& getPatterns(void);
-uint16_t getPalette(void);
-JsonArray& getPalettes(void);
-uint16_t getAutoplay(void); 
-uint16_t getAutoplayDuration(void);
-uint16_t getAutopal(void);
-uint16_t getAutopalDuration(void);
-uint16_t getSolidColor(void);
-uint16_t getCooling(void);
-uint16_t getSparking(void);
-uint16_t getSpeed(void);
-uint16_t getTwinkleSpeed(void);
-uint16_t getTwinkleDensity(void);
-uint16_t getBlendType(void);
-JsonArray& getBlendTypes(void);
-uint16_t getReverse(void);
-uint16_t getHueTime(void);
-uint16_t getDeltaHue(void);
+Field getField(const char * name);
+String getFieldValue(const char * name);
+void setFieldValue(const char * name, uint32_t value);
+bool isField(const char * name);
+const Field * getFields(void);
+uint8_t getFieldCount(void);
+// writes all Name / value pairs to the provided JSON Array
+// "values": [
+//    {
+//       "name": "power",
+//       "value": 0
+//    },
+//    {
+//       "name": "effect",
+//       "value": 0
+//    },
+//    {
+//       "name": "brightness",
+//       "value": 200
+//    },
+// returns true if at least on object was written
+bool getAllValuesJSONArray(JsonArray &arr);
 
-extern FieldList fields;
-extern uint8_t fieldCount;
+// writes all fields to the JSON obj as array.
+// {
+// "name": "power",
+// "label": "On/Off",
+// "type": 1,
+// "value": 0
+// },
+// {
+// "name": "effect",
+// "label": "Effect",
+// "type": 2,
+// "value": 0,
+// "options": [
+// "Static",
+// "Ease",
+// returns true if at least on object was written
+void getAllJSON(JsonArray &arr);
+// writes all Name / value pairs to the provided JSON
+// "power": "off",
+// "effect": "Static",
+// "brightness": "200"...
+bool getAllValuesJSON(JsonObject & obj);
 
 // /End Fields.h
 

--- a/src/WS2812FX/WS2812FX_FastLED.cpp
+++ b/src/WS2812FX/WS2812FX_FastLED.cpp
@@ -379,10 +379,10 @@ void WS2812FX::service()
       _segment.numBars = max(((LED_COUNT / _segment.segments) / MAX_NUM_BARS_FACTOR),1);
     }
     // 12.04.2019
-    // There are artefacts remeianing if the distribution is not equal.
+    // There are artefacts remaining if the distribution is not equal.
     // as we blend towards the new effect, we will remove the artefacts by clearing the leds array...
     fill_solid(leds, LED_COUNT, CRGB::Black);
-    fill_solid(_bleds, LED_COUNT, CRGB::Black);
+    //fill_solid(_bleds, LED_COUNT, CRGB::Black);
     
     setTransition();
     
@@ -526,6 +526,9 @@ if(LEDupdate && SEGMENT.mode == FX_MODE_VOID)
 // as the combination of "mirror" and "reverse" is a bit redundant, this could maybe be simplified as well (later)
 if(LEDupdate)
 {
+  // try to generally fade a bit to slowly remove any artefacts remaining
+  // this should not affect the effect running as long the the l_blend value is 255
+  fadeToBlackBy(_bleds, LED_COUNT, 1);
   for (uint16_t j = 0; j < _segment.segments; j++)
   {
     for (uint16_t i = 0; i < _segment_runtime.length; i++)

--- a/src/WS2812FX/WS2812FX_FastLed.h
+++ b/src/WS2812FX/WS2812FX_FastLed.h
@@ -514,7 +514,6 @@ public:
     uint16_t start;
     uint16_t stop;
     uint16_t length;
-    // uint32_t timebase;
     uint32_t nextHue;
     uint32_t nextAuto;
     uint32_t nextPalette;
@@ -523,16 +522,16 @@ public:
   } segment_runtime;
 
 public:
-  WS2812FX(const uint8_t volt = 5,
+  WS2812FX(CRGB * pleds, CRGB* eleds, const uint8_t volt = 5,
            const LEDColorCorrection colc = TypicalLEDStrip)
   {
 
-    physicalLeds = new CRGB[LED_COUNT_TOT];
+    physicalLeds = pleds; //= new CRGB[LED_COUNT_TOT];
     _bleds = &physicalLeds[LED_OFFSET];
-    leds = new CRGB[LED_COUNT];
+    leds = eleds; // new CRGB[LED_COUNT];
 
     FastLED.addLeds<WS2812, LED_PIN, GRB>(physicalLeds, LED_COUNT_TOT);
-    FastLED.setCorrection(_segment.colCor); //TypicalLEDStrip);
+    FastLED.setCorrection(_segment.colCor); 
 
 
     _mode[FX_MODE_STATIC]                 = &WS2812FX::mode_static;
@@ -690,8 +689,8 @@ public:
 
   ~WS2812FX()
   {
-    delete leds;
-    delete _bleds;
+    //delete leds;
+    //delete _bleds;
   }
 
   CRGB *leds;
@@ -769,12 +768,13 @@ public:
   inline void setBckndHue             (uint8_t h)       { _segment.backgroundHue = h; }
   inline void setBckndBri             (uint8_t b)       { _segment.backgroundBri = constrain(b, BCKND_MIN_BRI, BCKND_MAX_BRI); }
   inline void setColCor               (COLORCORRECTIONS c) { _segment.colCor = (COLORCORRECTIONS)constrain(c, 0, COR_NUMCORRECTIONS-1); FastLED.setCorrection(colorCorrectionValues[_segment.colCor]);}
+  inline void setSolidColor           (uint32_t c)      { _segment.solidColor = CRGB(c); }
 
   inline void setTransition           (void)            { _transition = true; _segment_runtime.modeinit = true; _blend = 0; }
   
   // getters
-  inline size_t         getCRCsize(void)          { return sizeof(_segment.CRC); }
-    
+  inline size_t         getCRCsize(void)              { return sizeof(_segment.CRC); }
+  inline CRGB           getSolidColor(void)           { return _segment.solidColor; }
   inline uint16_t       getCRC(void)                  { return _segment.CRC; }
   inline bool           isRunning(void)               { return _segment.isRunning; }
   inline bool           getPower(void)                { return _segment.power; }


### PR DESCRIPTION
Fixes #45
Also:
- Do not switch to Black during e.g. change in segment numbers.
- make the leds / _bleds arrays globals and pass a reference: This should save a lot of heap.... lets see.
- changed the interface to the fields.. no need to address them directly.